### PR TITLE
added lexical editor as react widget with usj file handling

### DIFF
--- a/packages/usfm-editor/package.json
+++ b/packages/usfm-editor/package.json
@@ -9,8 +9,8 @@
     "src"
   ],
   "dependencies": {
-    "@biblionexus-foundation/scribe-editor": "^0.0.4",
-    "@biblionexus-foundation/scripture-utilities": "^0.0.4",
+    "@biblionexus-foundation/scribe-editor": "^0.1.0",
+    "@biblionexus-foundation/scripture-utilities": "^0.0.7",
     "@theia/core": "1.51.0",
     "@theia/editor": "1.51.0",
     "@theia/plugin": "1.51.0",

--- a/packages/usfm-editor/src/browser/custom-file-widget.tsx
+++ b/packages/usfm-editor/src/browser/custom-file-widget.tsx
@@ -31,11 +31,10 @@ export class CustomFileWidget extends ReactWidget implements Saveable {
     if (this.currentUsj && this.uri) {
       console.log("Frontend: Saving file");
       try {
-        // Convert USJ back to USFM
         await this.serializeContent();
         // Save the USFM content to file
-        console.log("Frontend: Writing to file:", this.uri, this.currentUsfm);
-        await this.fileService.write(this.uri, this.currentUsfm);
+        console.log("Frontend: Writing to file:", this.uri, this.editedUsj);
+        await this.fileService.write(this.uri, this.editedUsj);
         // await this.fileService.write(fileToWrite, content);
 
         this.dirty = false;
@@ -47,7 +46,7 @@ export class CustomFileWidget extends ReactWidget implements Saveable {
       }
     }
   }
-  private currentUsfm: string;
+  private editedUsj: string;
   private bookId: string;
   private currentUsj: Usj | null = null;
   static readonly ID = "custom-file-widget";
@@ -100,11 +99,8 @@ export class CustomFileWidget extends ReactWidget implements Saveable {
   }
 
   protected async parseContent(): Promise<void> {
-    console.log("Frontend: parseContent called");
-    const jsonString = await this.fileProcessorService.processFileContent(
-      this.fileContent
-    );
-    this.processedContent = JSON.parse(jsonString);
+    console.log("Frontend: parseContent called", this.fileContent);
+    this.processedContent = JSON.parse(this.fileContent);
     console.log("Frontend: Processed content received");
     this.dirty = true;
     this.onDirtyChangedEmitter.fire(undefined);
@@ -113,11 +109,12 @@ export class CustomFileWidget extends ReactWidget implements Saveable {
   protected async serializeContent(): Promise<void> {
     console.log("Frontend: serializeContent called");
     if (this.currentUsj) {
-      const usfm = await this.fileProcessorService.serializeUsj(
-        this.currentUsj
-      );
-      this.currentUsfm = usfm;
-      console.log("Frontend: Serialized content:", usfm);
+      // const usfm = await this.fileProcessorService.serializeUsj(
+      //   this.currentUsj
+      // );
+      const usj = JSON.stringify(this.currentUsj);
+      this.editedUsj = usj;
+      console.log("Frontend: Serialized content:", usj);
     }
   }
 

--- a/packages/usfm-editor/src/browser/file-opener-handler.ts
+++ b/packages/usfm-editor/src/browser/file-opener-handler.ts
@@ -1,41 +1,47 @@
-
-import { injectable, inject } from '@theia/core/shared/inversify';
-import { OpenHandler, OpenerOptions, WidgetManager, ApplicationShell } from '@theia/core/lib/browser';
-import URI from '@theia/core/lib/common/uri';
+import { injectable, inject } from "@theia/core/shared/inversify";
+import {
+  OpenHandler,
+  OpenerOptions,
+  WidgetManager,
+  ApplicationShell,
+} from "@theia/core/lib/browser";
+import URI from "@theia/core/lib/common/uri";
 // import { MaybePromise } from '@theia/core/lib/common/types';
-import { CustomFileWidget } from './custom-file-widget';
+import { CustomFileWidget } from "./custom-file-widget";
 
 @injectable()
 export class FileOpenHandler implements OpenHandler {
-    readonly id = 'custom-file-open-handler';
-    readonly label = 'Custom File Open Handler';
+  readonly id = "custom-file-open-handler";
+  readonly label = "Custom File Open Handler";
 
-    @inject(WidgetManager)
-    protected readonly widgetManager: WidgetManager;
+  @inject(WidgetManager)
+  protected readonly widgetManager: WidgetManager;
 
-    @inject(ApplicationShell)
-    protected readonly shell: ApplicationShell;
+  @inject(ApplicationShell)
+  protected readonly shell: ApplicationShell;
 
-    canHandle(uri: URI): number {
-      return uri.path.ext.toLowerCase() === '.usfm' ? 500 : 0;
+  canHandle(uri: URI): number {
+    return uri.path.ext.toLowerCase() === ".usj" ? 500 : 0;
+  }
+
+  async open(uri: URI, options?: OpenerOptions): Promise<CustomFileWidget> {
+    console.log("USJ File opened:", uri.toString());
+    const widget = await this.widgetManager.getOrCreateWidget<CustomFileWidget>(
+      CustomFileWidget.ID,
+      {
+        factoryId: CustomFileWidget.ID,
+      }
+    );
+    if (widget instanceof CustomFileWidget) {
+      await widget.setUri(uri);
     }
-
-    async open(uri: URI, options?: OpenerOptions): Promise<CustomFileWidget> {
-        console.log('USFM File opened:', uri.toString());
-        const widget = await this.widgetManager.getOrCreateWidget<CustomFileWidget>(CustomFileWidget.ID, {
-            factoryId: CustomFileWidget.ID
-        });
-        if (widget instanceof CustomFileWidget) {
-            await widget.setUri(uri);
-        }
-        if (!widget.isAttached) {
-            this.shell.addWidget(widget, { area: 'main' });
-        }
-        this.shell.activateWidget(widget.id);
-        return widget;
+    if (!widget.isAttached) {
+      this.shell.addWidget(widget, { area: "main" });
     }
+    this.shell.activateWidget(widget.id);
+    return widget;
+  }
 }
-
 
 // @injectable()
 // export class FileOpenHandler implements OpenHandler {

--- a/packages/usfm-editor/src/browser/lexical-editor.tsx
+++ b/packages/usfm-editor/src/browser/lexical-editor.tsx
@@ -26,7 +26,7 @@ export interface ScriptureReference {
 }
 const defaultUsj: Usj = {
   type: "USJ",
-  version: "0.2.1",
+  version: "3.1",
   content: [],
 };
 const defaultScrRef: ScriptureReference = {
@@ -108,7 +108,7 @@ export default function LexicalEditor({
 
   return (
     <div className="lexical-editor-container">
-      <div className="editor-wrapper p-4">
+      <div className="editor-wrapper p-4 text-gray-600">
         <Editor
           usjInput={usj}
           ref={editorRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,32 +1240,25 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@biblionexus-foundation/scribe-editor@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@biblionexus-foundation/scribe-editor/-/scribe-editor-0.0.4.tgz#3c17eb636ed06a70712a0cb8e456d93e75350dd5"
-  integrity sha512-t5fSCQ9Gb/BFyfed4azZTngSqf4tPc4YEwlvycgcPQfA0RQ+laGnPjmEIka41GU3P3rt2GnZ2YmFqCt2/7/Myw==
+"@biblionexus-foundation/scribe-editor@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@biblionexus-foundation/scribe-editor/-/scribe-editor-0.1.0.tgz#873fcd56b07daf2074c65848b985f4fcac009d67"
+  integrity sha512-jgxjUOCBSJC3f2GKCJqR4RW5nMpz7nUCpLXI0mHnigR05tpFJ5ji17WRBvkmxAXq9HW5YCnzChAre8hLIfJjuA==
   dependencies:
-    "@biblionexus-foundation/scripture-utilities" "^0.0.3"
-    "@lexical/mark" "^0.16.0"
-    "@lexical/react" "^0.16.0"
-    "@lexical/selection" "^0.16.0"
-    "@lexical/utils" "^0.16.0"
+    "@biblionexus-foundation/scripture-utilities" "~0.0.7"
+    "@lexical/mark" "^0.21.0"
+    "@lexical/react" "^0.21.0"
+    "@lexical/selection" "^0.21.0"
+    "@lexical/utils" "^0.21.0"
     fast-equals "^5.0.1"
-    lexical "^0.16.0"
+    lexical "^0.21.0"
 
-"@biblionexus-foundation/scripture-utilities@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@biblionexus-foundation/scripture-utilities/-/scripture-utilities-0.0.3.tgz#b1b5d65d58745c82058b2ce74287699a0878ca0d"
-  integrity sha512-Mu0G7wvsZ1hV9BknwXYIPgVpG93fyALPJXsPVSlvkD9SjA+xhsAqQV9hM3x/4SReN9eNlqfCnB6jEH9H/877/Q==
+"@biblionexus-foundation/scripture-utilities@^0.0.7", "@biblionexus-foundation/scripture-utilities@~0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@biblionexus-foundation/scripture-utilities/-/scripture-utilities-0.0.7.tgz#1162f036711754f5487bd55009f1f5bac26959a7"
+  integrity sha512-1PqRGamRokIQ4NeoJMCjahGRtQKQzMssyTwHUn35Ph26oXnANdhwcxk5xiZFnSPoGUfv2J47B8NfOuMQFok94A==
   dependencies:
-    "@xmldom/xmldom" "^0.8.10"
-
-"@biblionexus-foundation/scripture-utilities@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@biblionexus-foundation/scripture-utilities/-/scripture-utilities-0.0.4.tgz#aac4cd5c7ffd98b60990b661b475f2c0f8a5a832"
-  integrity sha512-EslK90TulsLaePMRhcJV/lClFC7NTdbQXbNCXbMN4rR07ES9ZSqKRKaMelNOtWh0eZgXa+glBf7mPC2vdwM6uQ==
-  dependencies:
-    "@xmldom/xmldom" "^0.8.10"
+    "@xmldom/xmldom" "^0.9.6"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -1637,206 +1630,208 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lexical/clipboard@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/clipboard/-/clipboard-0.16.1.tgz#50d09887eeceab1debbc2428a02b8135b66c4e1d"
-  integrity sha512-0dWs/SwKS5KPpuf6fUVVt9vSCl6HAqcDGhSITw/okv0rrIlXTUT6WhVsMJtXfFxTyVvwMeOecJHvQH3i/jRQtA==
+"@lexical/clipboard@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/clipboard/-/clipboard-0.21.0.tgz#c81aa3f66fdb0ccb05a9d6d1bf7e84233166cf17"
+  integrity sha512-3lNMlMeUob9fcnRXGVieV/lmPbmet/SVWckNTOwzfKrZ/YW5HiiyJrWviLRVf50dGXTbmBGt7K/2pfPYvWCHFA==
   dependencies:
-    "@lexical/html" "0.16.1"
-    "@lexical/list" "0.16.1"
-    "@lexical/selection" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/html" "0.21.0"
+    "@lexical/list" "0.21.0"
+    "@lexical/selection" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/code@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/code/-/code-0.16.1.tgz#c62df85881b03485ea4b4492d0dadc6682ddb983"
-  integrity sha512-pOC28rRZ2XkmI2nIJm50DbKaCJtk5D0o7r6nORYp4i0z+lxt5Sf2m82DL9ksUHJRqKy87pwJDpoWvJ2SAI0ohw==
+"@lexical/code@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/code/-/code-0.21.0.tgz#ceb4ad6114dbe7d3f214fb6150226d5f9d59d1db"
+  integrity sha512-E0DNSFu4I+LMn3ft+UT0Dbntc8ZKjIA0BJj6BDewm0qh3bir40YUf5DkI2lpiFNRF2OpcmmcIxakREeU6avqTA==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
     prismjs "^1.27.0"
 
-"@lexical/devtools-core@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/devtools-core/-/devtools-core-0.16.1.tgz#e166e08c74735f8837843b3e3da4492312cdbc58"
-  integrity sha512-8CvGERGL7ySDVGLU+YPeq+JupIXsOFlXa3EuJ88koLKqXxYenwMleZgGqayFp6lCP78xqPKnATVeoOZUt/NabQ==
+"@lexical/devtools-core@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/devtools-core/-/devtools-core-0.21.0.tgz#b8af559f90da0aaee83826b8ad92537305176663"
+  integrity sha512-csK41CmRLZbKNV5pT4fUn5RzdPjU5PoWR8EqaS9kiyayhDg2zEnuPtvUYWanLfCLH9A2oOfbEsGxjMctAySlJw==
   dependencies:
-    "@lexical/html" "0.16.1"
-    "@lexical/link" "0.16.1"
-    "@lexical/mark" "0.16.1"
-    "@lexical/table" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/html" "0.21.0"
+    "@lexical/link" "0.21.0"
+    "@lexical/mark" "0.21.0"
+    "@lexical/table" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/dragon@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/dragon/-/dragon-0.16.1.tgz#bc122770fe3bd8002f057b99d4ca5aee95ec3b31"
-  integrity sha512-Rvd60GIYN5kpjjBumS34EnNbBaNsoseI0AlzOdtIV302jiHPCLH0noe9kxzu9nZy+MZmjZy8Dx2zTbQT2mueRw==
+"@lexical/dragon@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/dragon/-/dragon-0.21.0.tgz#d3d89887e75650ede1572c57b70e650210586a7a"
+  integrity sha512-ahTCaOtRFNauEzplN1qVuPjyGAlDd+XcVM5FQCdxVh/1DvqmBxEJRVuCBqatzUUVb89jRBekYUcEdnY9iNjvEQ==
   dependencies:
-    lexical "0.16.1"
+    lexical "0.21.0"
 
-"@lexical/hashtag@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/hashtag/-/hashtag-0.16.1.tgz#4a55b8f03f2754d39a15e44e30a80bdc6fb1710b"
-  integrity sha512-G+YOxStAKs3q1utqm9KR4D4lCkwIH52Rctm4RgaVTI+4lvTaybeDRGFV75P/pI/qlF7/FvAYHTYEzCjtC3GNMQ==
+"@lexical/hashtag@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/hashtag/-/hashtag-0.21.0.tgz#bfcf209d4995d7b2815e5e1b43a5266bba654dec"
+  integrity sha512-O4dxcZNq1Xm45HLoRifbGAYvQkg3qLoBc6ibmHnDqZL5mQDsufnH6QEKWfgDtrvp9++3iqsSC+TE7VzWIvA7ww==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/history@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/history/-/history-0.16.1.tgz#1c9f4f06f4bcdc2e91cfd6dac7c508633e7779d2"
-  integrity sha512-WQhScx0TJeKSQAnEkRpIaWdUXqirrNrom2MxbBUc/32zEUMm9FzV7nRGknvUabEFUo7vZq6xTZpOExQJqHInQA==
+"@lexical/history@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/history/-/history-0.21.0.tgz#96c0d31f6ef6a1ea68c73ab51b07f694ee194e58"
+  integrity sha512-Sv2sici2NnAfHYHYRSjjS139MDT8fHP6PlYM2hVr+17dOg7/fJl22VBLRgQ7/+jLtAPxQjID69jvaMlOvt4Oog==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/html@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/html/-/html-0.16.1.tgz#40211fda59246ff797a63b060787cb76a31608d2"
-  integrity sha512-vbtAdCvQ3PaAqa5mFmtmrvbiAvjCu1iXBAJ0bsHqFXCF2Sba5LwHVe8dUAOTpfEZEMbiHfjul6b5fj4vNPGF2A==
+"@lexical/html@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/html/-/html-0.21.0.tgz#658535152b07982da01d8346a2afe3f4837cc669"
+  integrity sha512-UGahVsGz8OD7Ya39qwquE+JPStTxCw/uaQrnUNorCM7owtPidO2H+tsilAB3A1GK3ksFGdHeEjBjG0Gf7gOg+Q==
   dependencies:
-    "@lexical/selection" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/selection" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/link@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/link/-/link-0.16.1.tgz#ba15ca875f9f7f37aef7d6bc7f3f010168571e31"
-  integrity sha512-zG36gEnEqbIe6tK/MhXi7wn/XMY/zdivnPcOY5WyC3derkEezeLSSIFsC1u5UNeK5pbpNMSy4LDpLhi1Ww4Y5w==
+"@lexical/link@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/link/-/link-0.21.0.tgz#3bf5d36d909e19ec6da545ccf860e518ace70f56"
+  integrity sha512-/coktIyRXg8rXz/7uxXsSEfSQYxPIx8CmignAXWYhcyYtCWA0fD2mhEhWwVvHH9ofNzvidclRPYKUnrmUm3z3Q==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/list@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/list/-/list-0.16.1.tgz#109c0c1e9ea8b19e9a89c2887b831690e05f20a7"
-  integrity sha512-i9YhLAh5N6YO9dP+R1SIL9WEdCKeTiQQYVUzj84vDvX5DIBxMPUjTmMn3LXu9T+QO3h1s2L/vJusZASrl45eAw==
+"@lexical/list@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/list/-/list-0.21.0.tgz#e676e800532408b9087c9d5336a420800f69c3a3"
+  integrity sha512-WItGlwwNJCS8b6SO1QPKzArShmD+OXQkLbhBcAh+EfpnkvmCW5T5LqY+OfIRmEN1dhDOnwqCY7mXkivWO8o5tw==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/mark@0.16.1", "@lexical/mark@^0.16.0":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/mark/-/mark-0.16.1.tgz#942465a7d34858a559ad29410c5d543f1c340708"
-  integrity sha512-CZRGMLcxn5D+jzf1XnH+Z+uUugmpg1mBwTbGybCPm8UWpBrKDHkrscfMgWz62iRWz0cdVjM5+0zWpNElxFTRjQ==
+"@lexical/mark@0.21.0", "@lexical/mark@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/mark/-/mark-0.21.0.tgz#baf8752386ff76567ef0662aa6b76548db15e31b"
+  integrity sha512-2x/LoHDYPOkZbKHz4qLFWsPywjRv9KggTOtmRazmaNRUG0FpkImJwUbbaKjWQXeESVGpzfL3qNFSAmCWthsc4g==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/markdown@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/markdown/-/markdown-0.16.1.tgz#3e68fbac6ce65f6331ae712bb7d494c885550e3d"
-  integrity sha512-0sBLttMvfQO/hVaIqpHdvDowpgV2CoRuWo2CNwvRLZPPWvPVjL4Nkb73wmi8zAZsAOTbX2aw+g4m/+k5oJqNig==
+"@lexical/markdown@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/markdown/-/markdown-0.21.0.tgz#74b62313992078de56a3daa6a3ef8e086f3c227d"
+  integrity sha512-XCQCyW5ujK0xR6evV8sF0hv/MRUA//kIrB2JiyF12tLQyjLRNEXO+0IKastWnMKSaDdJMKjzgd+4PiummYs7uA==
   dependencies:
-    "@lexical/code" "0.16.1"
-    "@lexical/link" "0.16.1"
-    "@lexical/list" "0.16.1"
-    "@lexical/rich-text" "0.16.1"
-    "@lexical/text" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/code" "0.21.0"
+    "@lexical/link" "0.21.0"
+    "@lexical/list" "0.21.0"
+    "@lexical/rich-text" "0.21.0"
+    "@lexical/text" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/offset@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/offset/-/offset-0.16.1.tgz#e5fc9363fffe3abaa23c7212dfa363878c5bab15"
-  integrity sha512-/i2J04lQmFeydUZIF8tKXLQTXiJDTQ6GRnkfv1OpxU4amc0rwGa7+qAz/PuF1n58rP6InpLmSHxgY5JztXa2jw==
+"@lexical/offset@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/offset/-/offset-0.21.0.tgz#863cf7b237fda45007a0981e2dc1b1b43f79dd09"
+  integrity sha512-UR0wHg+XXbq++6aeUPdU0K41xhUDBYzX+AeiqU9bZ7yoOq4grvKD8KBr5tARCSYTy0yvQnL1ddSO12TrP/98Lg==
   dependencies:
-    lexical "0.16.1"
+    lexical "0.21.0"
 
-"@lexical/overflow@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/overflow/-/overflow-0.16.1.tgz#e791b3d19d6f5a8aeef5506441f1345ef2904bdb"
-  integrity sha512-xh5YpoxwA7K4wgMQF/Sjl8sdjaxqesLCtH5ZrcMsaPlmucDIEEs+i8xxk+kDUTEY7y+3FvRxs4lGNgX8RVWkvQ==
+"@lexical/overflow@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/overflow/-/overflow-0.21.0.tgz#3a27e52d452cf98150f57c5360b88b218cf18da9"
+  integrity sha512-93P+d1mbvaJvZF8KK2pG22GuS2pHLtyC7N3GBfkbyAIb7TL/rYs47iR+eADJ4iNY680lylJ4Sl/AEnWvlY7hAg==
   dependencies:
-    lexical "0.16.1"
+    lexical "0.21.0"
 
-"@lexical/plain-text@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/plain-text/-/plain-text-0.16.1.tgz#bb459d82f19280ff90676a457d50dbfe81d33780"
-  integrity sha512-GjY4ylrBZIaAVIF8IFnmW0XGyHAuRmWA6gKB8iTTlsjgFrCHFIYC74EeJSp309O0Hflg9rRBnKoX1TYruFHVwA==
+"@lexical/plain-text@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/plain-text/-/plain-text-0.21.0.tgz#8b8d103f5b5e691592876538b343618dfe23123c"
+  integrity sha512-r4CsAknBD7qGYSE5fPdjpJ6EjfvzHbDtuCeKciL9muiswQhw4HeJrT1qb/QUIY+072uvXTgCgmjUmkbYnxKyPA==
   dependencies:
-    "@lexical/clipboard" "0.16.1"
-    "@lexical/selection" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/clipboard" "0.21.0"
+    "@lexical/selection" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/react@^0.16.0":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/react/-/react-0.16.1.tgz#2cf6dadef79120413cb5264849acfe8efb7c1a5f"
-  integrity sha512-SsGgLt9iKfrrMRy9lFb6ROVPUYOgv6b+mCn9Al+TLqs/gBReDBi3msA7m526nrtBUKYUnjHdQ1QXIJzuKgOxcg==
+"@lexical/react@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/react/-/react-0.21.0.tgz#09f0ddc99047027e165332921cff2bd9ba493b9c"
+  integrity sha512-tKwx8EoNkBBKOZf8c10QfyDImH87+XUI1QDL8KXt+Lb8E4ho7g1jAjoEirNEn9gMBj33K4l2qVdbe3XmPAdpMQ==
   dependencies:
-    "@lexical/clipboard" "0.16.1"
-    "@lexical/code" "0.16.1"
-    "@lexical/devtools-core" "0.16.1"
-    "@lexical/dragon" "0.16.1"
-    "@lexical/hashtag" "0.16.1"
-    "@lexical/history" "0.16.1"
-    "@lexical/link" "0.16.1"
-    "@lexical/list" "0.16.1"
-    "@lexical/mark" "0.16.1"
-    "@lexical/markdown" "0.16.1"
-    "@lexical/overflow" "0.16.1"
-    "@lexical/plain-text" "0.16.1"
-    "@lexical/rich-text" "0.16.1"
-    "@lexical/selection" "0.16.1"
-    "@lexical/table" "0.16.1"
-    "@lexical/text" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    "@lexical/yjs" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/clipboard" "0.21.0"
+    "@lexical/code" "0.21.0"
+    "@lexical/devtools-core" "0.21.0"
+    "@lexical/dragon" "0.21.0"
+    "@lexical/hashtag" "0.21.0"
+    "@lexical/history" "0.21.0"
+    "@lexical/link" "0.21.0"
+    "@lexical/list" "0.21.0"
+    "@lexical/mark" "0.21.0"
+    "@lexical/markdown" "0.21.0"
+    "@lexical/overflow" "0.21.0"
+    "@lexical/plain-text" "0.21.0"
+    "@lexical/rich-text" "0.21.0"
+    "@lexical/selection" "0.21.0"
+    "@lexical/table" "0.21.0"
+    "@lexical/text" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    "@lexical/yjs" "0.21.0"
+    lexical "0.21.0"
     react-error-boundary "^3.1.4"
 
-"@lexical/rich-text@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/rich-text/-/rich-text-0.16.1.tgz#71f0b765b96071b0d6cf5fdde9ada0c5a5a0316c"
-  integrity sha512-4uEVXJur7tdSbqbmsToCW4YVm0AMh4y9LK077Yq2O9hSuA5dqpI8UbTDnxZN2D7RfahNvwlqp8eZKFB1yeiJGQ==
+"@lexical/rich-text@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/rich-text/-/rich-text-0.21.0.tgz#eb7b7b810888e6e6c62ea6634dad480e27c3f853"
+  integrity sha512-+pvEKUneEkGfWOSTl9jU58N9knePilMLxxOtppCAcgnaCdilOh3n5YyRppXhvmprUe0JaTseCMoik2LP51G/JA==
   dependencies:
-    "@lexical/clipboard" "0.16.1"
-    "@lexical/selection" "0.16.1"
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/clipboard" "0.21.0"
+    "@lexical/selection" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/selection@0.16.1", "@lexical/selection@^0.16.0":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/selection/-/selection-0.16.1.tgz#8a9756b377acf1c831440c588ad3d1789b02230f"
-  integrity sha512-+nK3RvXtyQvQDq7AZ46JpphmM33pwuulwiRfeXR5T9iFQTtgWOEjsAi/KKX7vGm70BxACfiSxy5QCOgBWFwVJg==
+"@lexical/selection@0.21.0", "@lexical/selection@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/selection/-/selection-0.21.0.tgz#5e144795633c53e8918cac819ae1a78f3c6f5c5f"
+  integrity sha512-4u53bc8zlPPF0rnHjsGQExQ1St8NafsDd70/t1FMw7yvoMtUsKdH7+ap00esLkJOMv45unJD7UOzKRqU1X0sEA==
   dependencies:
-    lexical "0.16.1"
+    lexical "0.21.0"
 
-"@lexical/table@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/table/-/table-0.16.1.tgz#ac0f15b3145720fcd3d53c7241042dc8ad354173"
-  integrity sha512-GWb0/MM1sVXpi1p2HWWOBldZXASMQ4c6WRNYnRmq7J/aB5N66HqQgJGKp3m66Kz4k1JjhmZfPs7F018qIBhnFQ==
+"@lexical/table@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/table/-/table-0.21.0.tgz#c1b0b28a38f4a1f91a5b28c4ea4b8c101ff0859a"
+  integrity sha512-JhylAWcf4qKD4FmxMUt3YzH5zg2+baBr4+/haLZL7178hMvUzJwGIiWk+3hD3phzmW3WrP49uFXzM7DMSCkE8w==
   dependencies:
-    "@lexical/utils" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/clipboard" "0.21.0"
+    "@lexical/utils" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/text@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.16.1.tgz#a028a2dd888536a32fa99d14183b148ec69211b6"
-  integrity sha512-Os/nKQegORTrKKN6vL3/FMVszyzyqaotlisPynvTaHTUC+yY4uyjM2hlF93i5a2ixxyiPLF9bDroxUP96TMPXg==
+"@lexical/text@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.21.0.tgz#323954fc7c6dc34e86f1948737e310ae708c9407"
+  integrity sha512-ceB4fhYejCoR8ID4uIs0sO/VyQoayRjrRWTIEMvOcQtwUkcyciKRhY0A7f2wVeq/MFStd+ajLLjy4WKYK5zUnA==
   dependencies:
-    lexical "0.16.1"
+    lexical "0.21.0"
 
-"@lexical/utils@0.16.1", "@lexical/utils@^0.16.0":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/utils/-/utils-0.16.1.tgz#f7bcd36eff2ac142ad72106e45fe0da219ec873e"
-  integrity sha512-BVyJxDQi/rIxFTDjf2zE7rMDKSuEaeJ4dybHRa/hRERt85gavGByQawSLeQlTjLaYLVsy+x7wCcqh2fNhlLf0g==
+"@lexical/utils@0.21.0", "@lexical/utils@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/utils/-/utils-0.21.0.tgz#600bbb7b1c6c3abe07d17c18229827e51308db50"
+  integrity sha512-YzsNOAiLkCy6R3DuP18gtseDrzgx+30lFyqRvp5M7mckeYgQElwdfG5biNFDLv7BM9GjSzgU5Cunjycsx6Sjqg==
   dependencies:
-    "@lexical/list" "0.16.1"
-    "@lexical/selection" "0.16.1"
-    "@lexical/table" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/list" "0.21.0"
+    "@lexical/selection" "0.21.0"
+    "@lexical/table" "0.21.0"
+    lexical "0.21.0"
 
-"@lexical/yjs@0.16.1":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@lexical/yjs/-/yjs-0.16.1.tgz#ed43581a1f96f581d36fd82f0b2e124a103fecd9"
-  integrity sha512-QHw1bmzB/IypIV1tRWMH4hhwE1xX7wV+HxbzBS8oJAkoU5AYXM/kyp/sQicgqiwVfpai1Px7zatOoUDFgbyzHQ==
+"@lexical/yjs@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@lexical/yjs/-/yjs-0.21.0.tgz#ff6fe6c03241d846a88e63d0f6b6332bf513b51e"
+  integrity sha512-AtPhC3pJ92CHz3dWoniSky7+MSK2WSd0xijc76I2qbTeXyeuFfYyhR6gWMg4knuY9Wz3vo9/+dXGdbQIPD8efw==
   dependencies:
-    "@lexical/offset" "0.16.1"
-    lexical "0.16.1"
+    "@lexical/offset" "0.21.0"
+    "@lexical/selection" "0.21.0"
+    lexical "0.21.0"
 
 "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"
@@ -4536,10 +4531,15 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
   integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
-"@xmldom/xmldom@^0.8.10", "@xmldom/xmldom@^0.8.8":
+"@xmldom/xmldom@^0.8.8":
   version "0.8.10"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
+
+"@xmldom/xmldom@^0.9.6":
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.7.tgz#f21bebdcde4af682a810062b14585c89bb7fab07"
+  integrity sha512-syvR8iIJjpTZ/stv7l89UAViwGFh6lbheeOaqSxkYx9YNmIVvPTRH+CT/fpykFtUx5N+8eSMDRvggF9J8GEPzQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -7448,10 +7448,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^28.2.8:
-  version "28.3.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.3.3.tgz#2df898f653c4f77b66b4cf3eeba79d8bea6d03c0"
-  integrity sha512-ObKMLSPNhomtCOBAxFS8P2DW/4umkh72ouZUlUKzXGtYuPzgr1SYhskhFWgzAsPtUzhL2CzyV2sfbHcEW4CXqw==
+electron@28.2.8:
+  version "28.2.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-28.2.8.tgz#b83d70ca00c0e767f0125fcec85f39aafe39ee4c"
+  integrity sha512-VgXw2OHqPJkobIC7X9eWh3atptjnELaP+zlbF9Oz00ridlaOWmtLPsp6OaXbLw35URpMr0iYesq8okKp7S0k+g==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"
@@ -10288,10 +10288,10 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-lexical@0.16.1, lexical@^0.16.0:
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/lexical/-/lexical-0.16.1.tgz#1d2cd3f364224889caa2939df179434af936283b"
-  integrity sha512-+R05d3+N945OY8pTUjTqQrWoApjC+ctzvjnmNETtx9WmVAaiW0tQVG+AYLt5pDGY8dQXtd4RPorvnxBTECt9SA==
+lexical@0.21.0, lexical@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/lexical/-/lexical-0.21.0.tgz#c2a1d4003aa1c445eeb2056e4a22ad9c69a2293b"
+  integrity sha512-Dxc5SCG4kB+wF+Rh55ism3SuecOKeOtCtGHFGKd6pj2QKVojtjkxGTQPMt7//2z5rMSue4R+hmRM0pCEZflupA==
 
 lighthouse-logger@^1.0.0:
   version "1.4.2"


### PR DESCRIPTION
Added lexical editor v0.1.0. 
Use usj files as source and write back to usj.
Currently, the editor works as a basic react widget. 
